### PR TITLE
calculate SHA-256 on stream rather than read all bytes

### DIFF
--- a/src/main/scala/org/dbpedia/databus/filehandling/FileUtil.scala
+++ b/src/main/scala/org/dbpedia/databus/filehandling/FileUtil.scala
@@ -2,7 +2,7 @@ package org.dbpedia.databus.filehandling
 
 import java.io.{FileInputStream, FileOutputStream, InputStream, OutputStream}
 import java.nio.file.Files
-import java.security.MessageDigest
+import java.security.{DigestInputStream, MessageDigest}
 
 import better.files.File
 import org.apache.commons.io.IOUtils
@@ -75,9 +75,13 @@ object FileUtil {
   }
 
   def getSha256(file:File) : String = {
-    MessageDigest.getInstance("SHA-256")
-      .digest(Files.readAllBytes(file.path))
-      .map("%02x".format(_)).mkString
+    val dis = new DigestInputStream(Files.newInputStream(file.path), MessageDigest.getInstance("SHA-256"))
+    // fully consume the inputstream
+    while (dis.available > 0) {
+      dis.read
+    }
+    dis.close
+    dis.getMessageDigest.digest.map("%02x".format(_)).mkString
   }
 
   def checkSum(file: File, sha: String): Boolean = {


### PR DESCRIPTION
When processing files over 2GB  and calculating SHA-256, the existing `Files.read_bytes` might cause `java.lang.OutOfMemoryError`
Actual complete stack trace:
```
https://downloads.dbpedia.org/repo/lts/generic/wikilinks/2019.08.30/wikilinks_lang=en.ttl.bz2 -> /home/eladshaked/download_ldc/databus-client/target/databus.tmp/cache_dir/downloads.dbpedia.org/repo/lts/generic/wikilinks/2019.08.30/wikilinks_lang=en.ttl.bz2
[INFO] Download: 2.0077264 GB of 2.0077264 GB in 46.664 seconds 44.05777 MB/ss
java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at scala_maven_executions.MainHelper.runMain(MainHelper.java:164)
	at scala_maven_executions.MainWithArgsInFile.main(MainWithArgsInFile.java:26)
Caused by: java.lang.OutOfMemoryError: Required array size too large
	at java.nio.file.Files.readAllBytes(Files.java:3156)
	at org.dbpedia.databus.filehandling.FileUtil$.getSha256(FileUtil.scala:79)
	at org.dbpedia.databus.filehandling.FileUtil$.checkSum(FileUtil.scala:84)
	at org.dbpedia.databus.filehandling.download.Downloader$.downloadFile(Downloader.scala:39)
	at org.dbpedia.databus.filehandling.download.Downloader$$anonfun$downloadWithQuery$1.apply(Downloader.scala:25)
	at org.dbpedia.databus.filehandling.download.Downloader$$anonfun$downloadWithQuery$1.apply(Downloader.scala:21)
	at scala.collection.immutable.List.foreach(List.scala:392)
	at org.dbpedia.databus.filehandling.download.Downloader$.downloadWithQuery(Downloader.scala:21)
	at org.dbpedia.databus.filehandling.SourceHandler$.handleQuery(SourceHandler.scala:47)
	at org.dbpedia.databus.main.Main$.main(Main.scala:38)
	at org.dbpedia.databus.main.Main.main(Main.scala)
	... 6 more
```