### PR TITLE
Add tool.poetry.scripts declaration

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -20,3 +20,6 @@ pytest = "^7.1.3"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.scripts]
+databusclient = "databusclient.cli:app()"


### PR DESCRIPTION
This allows to run the cli with `poetry run databusclient …`. Maybe also lets it be installed as cli with pipx.